### PR TITLE
:sparkles: Adding `CreateBucketResponse` assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ targetCompatibility = JavaVersion.VERSION_11
 
 ext {
     junitVersion = "5.8.1"
-    awsSdkVersion = "2.20.112"
+    awsSdkVersion = "2.20.133"
 }
 
 repositories {
@@ -25,6 +25,7 @@ repositories {
 dependencies {
     implementation("org.assertj:assertj-core:3.24.2")
     implementation("software.amazon.awssdk:sfn:${awsSdkVersion}")
+    implementation("software.amazon.awssdk:s3:${awsSdkVersion}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")

--- a/src/main/java/dev/joss/awssert/s3/CreateBucketResponseAssert.java
+++ b/src/main/java/dev/joss/awssert/s3/CreateBucketResponseAssert.java
@@ -1,0 +1,61 @@
+package dev.joss.awssert.s3;
+
+import dev.joss.awssert.mixins.StringFieldCheckMixin;
+import java.util.Optional;
+import org.assertj.core.api.AbstractAssert;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+
+public class CreateBucketResponseAssert
+    extends AbstractAssert<CreateBucketResponseAssert, CreateBucketResponse>
+    implements StringFieldCheckMixin {
+
+  private final String LOCATION_FIELD_NAME = "location";
+
+  private CreateBucketResponseAssert(CreateBucketResponse actual) {
+    super(actual, CreateBucketResponseAssert.class);
+  }
+
+  public static CreateBucketResponseAssert assertThat(CreateBucketResponse actual) {
+    return new CreateBucketResponseAssert(actual);
+  }
+
+  public CreateBucketResponseAssert hasLocation(String expected) {
+    isNotNull();
+    Optional<String> errorMessage =
+        hasFieldEqualToCheck(actual.location(), expected, LOCATION_FIELD_NAME);
+    errorMessage.ifPresent(this::failWithMessage);
+    return this;
+  }
+
+  public CreateBucketResponseAssert hasLocationStartingWith(String expectedPrefix) {
+    isNotNull();
+    Optional<String> errorMessage =
+        hasFieldThatStartsWith(actual.location(), expectedPrefix, LOCATION_FIELD_NAME);
+    errorMessage.ifPresent(this::failWithMessage);
+    return this;
+  }
+
+  public CreateBucketResponseAssert hasLocationEndingWith(String expectedSuffix) {
+    isNotNull();
+    Optional<String> errorMessage =
+        hasFieldThatEndsWith(actual.location(), expectedSuffix, LOCATION_FIELD_NAME);
+    errorMessage.ifPresent(this::failWithMessage);
+    return this;
+  }
+
+  public CreateBucketResponseAssert hasLocationContaining(String expectedSubstring) {
+    isNotNull();
+    Optional<String> errorMessage =
+        hasFieldThatContains(actual.location(), expectedSubstring, LOCATION_FIELD_NAME);
+    errorMessage.ifPresent(this::failWithMessage);
+    return this;
+  }
+
+  public CreateBucketResponseAssert hasLocationMatching(String expectedRegex) {
+    isNotNull();
+    Optional<String> errorMessage =
+        hasFieldThatMatchesRegex(actual.location(), expectedRegex, LOCATION_FIELD_NAME);
+    errorMessage.ifPresent(this::failWithMessage);
+    return this;
+  }
+}

--- a/src/main/java/dev/joss/awssert/sfn/GetExecutionHistoryResponseAssert.java
+++ b/src/main/java/dev/joss/awssert/sfn/GetExecutionHistoryResponseAssert.java
@@ -11,6 +11,10 @@ import software.amazon.awssdk.services.sfn.model.HistoryEvent;
 public class GetExecutionHistoryResponseAssert
     extends AbstractAssert<GetExecutionHistoryResponseAssert, GetExecutionHistoryResponse>
     implements CollectionFieldCheckMixin, StringFieldCheckMixin {
+
+  private final String EVENTS_FIELD_NAME = "events";
+  private final String TOKEN_FIELD_NAME = "nextToken";
+
   private GetExecutionHistoryResponseAssert(GetExecutionHistoryResponse actual) {
     super(actual, GetExecutionHistoryResponseAssert.class);
   }
@@ -21,14 +25,14 @@ public class GetExecutionHistoryResponseAssert
 
   public GetExecutionHistoryResponseAssert hasSomeEvents() {
     isNotNull();
-    Optional<String> errorMessage = hasFieldThatIsNotEmpty(actual.events(), "events");
+    Optional<String> errorMessage = hasFieldThatIsNotEmpty(actual.events(), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
 
   public GetExecutionHistoryResponseAssert hasNoEvents() {
     isNotNull();
-    Optional<String> errorMessage = hasFieldThatIsEmpty(actual.events(), "events");
+    Optional<String> errorMessage = hasFieldThatIsEmpty(actual.events(), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
@@ -41,7 +45,8 @@ public class GetExecutionHistoryResponseAssert
 
   public GetExecutionHistoryResponseAssert doesNotHaveEvent(HistoryEvent expectedEvent) {
     isNotNull();
-    Optional<String> errorMessage = hasFieldNotContaining(actual.events(), expectedEvent, "events");
+    Optional<String> errorMessage =
+        hasFieldNotContaining(actual.events(), expectedEvent, EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
@@ -49,7 +54,7 @@ public class GetExecutionHistoryResponseAssert
   public GetExecutionHistoryResponseAssert hasAnyEvents(HistoryEvent... expectedEvents) {
     isNotNull();
     Optional<String> errorMessage =
-        hasFieldContainingAnyOf(actual.events(), List.of(expectedEvents), "events");
+        hasFieldContainingAnyOf(actual.events(), List.of(expectedEvents), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
@@ -57,7 +62,7 @@ public class GetExecutionHistoryResponseAssert
   public GetExecutionHistoryResponseAssert hasAllEvents(HistoryEvent... expectedEvents) {
     isNotNull();
     Optional<String> errorMessage =
-        hasFieldContainingAllOf(actual.events(), List.of(expectedEvents), "events");
+        hasFieldContainingAllOf(actual.events(), List.of(expectedEvents), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
@@ -65,28 +70,30 @@ public class GetExecutionHistoryResponseAssert
   public GetExecutionHistoryResponseAssert hasExactlyEvents(HistoryEvent... expectedEvents) {
     isNotNull();
     Optional<String> errorMessage =
-        hasFieldContainingExactly(actual.events(), List.of(expectedEvents), "events");
+        hasFieldContainingExactly(actual.events(), List.of(expectedEvents), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
 
   public GetExecutionHistoryResponseAssert hasNoDuplicateEvents() {
     isNotNull();
-    Optional<String> errorMessage = hasFieldContainingNoDuplicates(actual.events(), "events");
+    Optional<String> errorMessage =
+        hasFieldContainingNoDuplicates(actual.events(), EVENTS_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
 
   public GetExecutionHistoryResponseAssert hasNextToken() {
     isNotNull();
-    Optional<String> errorMessage = hasFieldThatIsNotNullOrEmpty(actual.nextToken(), "nextToken");
+    Optional<String> errorMessage =
+        hasFieldThatIsNotNullOrEmpty(actual.nextToken(), TOKEN_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }
 
   public GetExecutionHistoryResponseAssert doesNotHaveNextToken() {
     isNotNull();
-    Optional<String> errorMessage = hasFieldThatIsNullOrEmpty(actual.nextToken(), "nextToken");
+    Optional<String> errorMessage = hasFieldThatIsNullOrEmpty(actual.nextToken(), TOKEN_FIELD_NAME);
     errorMessage.ifPresent(this::failWithMessage);
     return this;
   }

--- a/src/test/java/dev/joss/awssert/s3/CreateBucketResponseAssertTest.java
+++ b/src/test/java/dev/joss/awssert/s3/CreateBucketResponseAssertTest.java
@@ -1,0 +1,141 @@
+package dev.joss.awssert.s3;
+
+import static dev.joss.awssert.s3.CreateBucketResponseAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+
+class CreateBucketResponseAssertTest {
+
+  @Test
+  void checkHasLocationPassesWithValidLocation() {
+    String location = "/very/valid/s3-location";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    assertThat(actual).hasLocation(location);
+  }
+
+  @Test
+  void checkHasLocationFailsWithoutLocation() {
+    String location = "/very/valid/s3-location";
+    CreateBucketResponse actual = CreateBucketResponse.builder().build();
+
+    AssertionError assertionError = failsAssertion(() -> assertThat(actual).hasLocation(location));
+    String expectedMessage =
+        String.format(
+            "Expected location to be equal to <%s> but was <%s>", location, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void checkHasLocationFailsWithInvalidLocation() {
+    String location = "/very/valid/s3-location";
+    CreateBucketResponse actual =
+        CreateBucketResponse.builder().location("/not-the-actual-location").build();
+
+    AssertionError assertionError = failsAssertion(() -> assertThat(actual).hasLocation(location));
+    String expectedMessage =
+        String.format(
+            "Expected location to be equal to <%s> but was <%s>", location, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void checkHasLocationStartingWithPassesWithValidInput() {
+    String location = "/very/valid/s3-location";
+    String locationPrefix = location.substring(0, 3);
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    assertThat(actual).hasLocationStartingWith(locationPrefix);
+  }
+
+  @Test
+  void checkHasLocationStartingWithFailsWithInvalidInput() {
+    String location = "/very/valid/s3-location";
+    String locationPrefix = "not-the-actual-prefix";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    AssertionError assertionError =
+        failsAssertion(() -> assertThat(actual).hasLocationStartingWith(locationPrefix));
+    String expectedMessage =
+        String.format(
+            "Expected location to start with <%s> but was <%s>", locationPrefix, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void checkHasLocationEndingWithPassesWithValidInput() {
+    String location = "/very/valid/s3-location";
+    String locationSuffix = location.substring(3);
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    assertThat(actual).hasLocationEndingWith(locationSuffix);
+  }
+
+  @Test
+  void checkHasLocationEndingWithFailsWithInvalidInput() {
+    String location = "/very/valid/s3-location";
+    String locationSuffix = "not-the-suffix";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    AssertionError assertionError =
+        failsAssertion(() -> assertThat(actual).hasLocationEndingWith(locationSuffix));
+    String expectedMessage =
+        String.format(
+            "Expected location to end with <%s> but was <%s>", locationSuffix, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void checkHasLocationContainingPassesWithValidInput() {
+    String location = "/very/valid/s3-location";
+    String locationSubstring = location.substring(3, 13);
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    assertThat(actual).hasLocationContaining(locationSubstring);
+  }
+
+  @Test
+  void checkHasLocationContainingFailsWithInvalidInput() {
+    String location = "/very/valid/s3-location";
+    String locationSubstring = "not-a-substring";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    AssertionError assertionError =
+        failsAssertion(() -> assertThat(actual).hasLocationContaining(locationSubstring));
+    String expectedMessage =
+        String.format(
+            "Expected location to contain <%s> but was <%s>", locationSubstring, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void checkHasLocationMatchingPassesWithValidInput() {
+    String location = "/very/valid/s3-location";
+    String locationRegex = "/very/valid/.*";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    assertThat(actual).hasLocationMatching(locationRegex);
+  }
+
+  @Test
+  void checkHasLocationMatchingFailsWithInvalidInput() {
+    String location = "/very/valid/s3-location";
+    String locationRegex = "not-a-matching-regex";
+    CreateBucketResponse actual = CreateBucketResponse.builder().location(location).build();
+
+    AssertionError assertionError =
+        failsAssertion(() -> assertThat(actual).hasLocationMatching(locationRegex));
+    String expectedMessage =
+        String.format(
+            "Expected location to match regex <%s> but was <%s>", locationRegex, actual.location());
+    assertThat(assertionError.getMessage()).isEqualTo(expectedMessage);
+  }
+
+  public AssertionError failsAssertion(Executable executable) {
+    return assertThrows(AssertionError.class, executable);
+  }
+}


### PR DESCRIPTION
# Description
Adds the functionality specified in #6 to add assertions for all the relevant fields in the `CreateBucketResponse` java sdk model

Fixes #6 

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules